### PR TITLE
Move evidence spans and source scanning to Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ The Python layer owns orchestration, prompts, model clients, indexing, the API-b
 
 Driven by `build_kb_index_transactional` whenever a KB's supported sources change through Web/API upload, connector synchronization, deletion, CLI maintenance, or an explicit rebuild:
 
-1. **Scan** — an all-PDF corpus uses `scan_pdf_manifest_native` (Rust) for rayon-parallel, 1 MiB-buffered SHA-256; mixed-format corpora use the format-neutral source scanner. Both return a filename-sorted `{doc_id, documents: [{name, size, sha256}]}` manifest.
+1. **Scan** — source manifests are hashed in Rust with rayon-parallel, 1 MiB-buffered SHA-256. The all-PDF compatibility path uses `scan_pdf_manifest_native`; mixed-format corpora use `scan_source_manifest_native` with the Python product layer supplying the supported-extension allowlist and per-file byte limit. Both return a filename-sorted `{doc_id, documents: [{name, size, sha256}]}` manifest.
 2. **Compare** — `manifests_match` reuses the index only if `doc_id`, `chunk_identity_version`, and every `{name, sha256}` match the saved manifest; any mismatch forces a rebuild.
 3. **Parse** — PDFs use `smart_parse` / PyMuPDF for page text, block-aware two-column reflow, and optional bounded local Tesseract OCR. The format-neutral `parse_source` path preserves appropriate locators for Markdown/text/HTML lines and sections, DOCX paragraphs, PPTX slides, XLSX sheets/cells, and supported images.
 4. **Chunk** — `chunk_paper` first detects conservative section spans, then keeps each child under 600 chars with 60-char overlap, preferring paragraph, sentence/semicolon, newline, and whitespace boundaries before falling back to a fixed window for very long unbroken text. The legacy 30-character minimum still filters unstructured noise, while every non-empty detected section or preamble is retained so structural boundaries cannot erase short evidence. Children never cross a detected section boundary. Each child stores a stable `parent_chunk_id`, section breadcrumb and within-parent order, plus up to 160 chars of section-bounded context; its own stable `chunk_id` and page span remain the citation identity.
@@ -688,15 +688,18 @@ chunk_id = sha256:{source_sha256}:src:{source_name}:p{page_start}-p{page_end}:c{
 
 ## Native Core
 
-`rust_core` is a PyO3/maturin extension, loaded via `tools.rust_core_loader.ensure_rust_core`, which fails fast with a `maturin develop` hint if the build is missing or a symbol is stale. It exposes six native symbols, all listed in `scripts/check_native.py` so `make check` fails against a stale build.
+`rust_core` is a PyO3/maturin extension, loaded via `tools.rust_core_loader.ensure_rust_core`, which fails fast with a `maturin develop` hint if the build is missing or a symbol is stale. Its required native symbols are all listed in `scripts/check_native.py` so `make check` fails against a stale build.
 
 | Symbol | Module | Purpose |
 | --- | --- | --- |
-| `scan_pdf_manifest_native` | `scanner.rs` | Rayon-parallel, buffered SHA-256 all-PDF fast path; mixed formats use the Python source scanner |
+| `scan_pdf_manifest_native` | `scanner.rs` | Rayon-parallel, buffered SHA-256 all-PDF compatibility path |
+| `list_supported_files_native` | `scanner.rs` | Stable format-allowlisted file enumeration shared with manifest scanning |
+| `scan_source_manifest_native` | `scanner.rs` | Format-neutral, allowlisted parallel SHA-256 scan with a fail-closed per-file size limit |
 | `rrf_fusion_native` | `rrf.rs` | Deterministic RRF (`k=60`) merge of vector + BM25 results, keyed on `chunk_id` |
 | `validate_citations_native` | `citation.rs` | Structured citation check → `invalid_sources` / `invalid_pages` / `missing_citations` |
 | `tokenize_mixed_text_native` | `tokenizer.rs` | Mixed CN/EN tokenizer: `jieba-rs` for Chinese, Snowball stemming + stopword removal for English (identifiers/versions kept verbatim); token-for-token aligned with a Python reference |
 | `tokenize_corpus_native` | `tokenizer.rs` | Batch corpus tokenizer used by BM25 indexing to avoid Python-side per-document tokenization loops |
+| `select_evidence_span_native` | `evidence_span.rs` | Query-aware sentence/window scoring in one native call; Python retains provenance and ACL materialization |
 | `Bm25Index` (class) | `bm25.rs` | BM25 index + `score_topk` + native bytes persistence, bit-aligned with `rank_bm25.BM25Okapi`; top-k selected natively |
 
 ## Project Layout
@@ -738,7 +741,7 @@ CogDoc/
 | `src/cogdoc/graph/` | LangGraph state, main workflow, and QA / Summary / Compare subgraphs |
 | `src/cogdoc/service/` | Chat / ingest services, KB lifecycle, transactional indexing, locks, cleanup, and background work |
 | `src/cogdoc/tools/` | Format-neutral source parsing, PDF/OCR handling, chunking, manifests, embedding, rerank, Rust loading, and retrievers |
-| `rust_core/src/` | PyO3 native core: scanner, tokenizer, BM25, RRF, citation validator |
+| `rust_core/src/` | PyO3 native core: scanner, tokenizer, evidence-span selector, BM25, RRF, citation validator |
 | `scripts/`, `tests/`, `eval/`, `docs/` | Health-check scripts, tests, offline eval sets, and project docs |
 
 ## Configuration

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -600,7 +600,7 @@ Python 层负责图编排、Prompt、模型客户端、索引、API CLI、离线
 
 由 `build_kb_index_transactional` 在知识库的受支持来源经 Web/API 上传、连接器同步、删除、CLI 维护或显式重建发生变化时驱动：
 
-1. **扫描** — 全部为 PDF 时走 `scan_pdf_manifest_native`（Rust）的 rayon 并行、1 MiB 缓冲 SHA-256 快速路径；混合格式语料走统一来源扫描器。两者都会返回按文件名排序的 `{doc_id, documents: [{name, size, sha256}]}` manifest。
+1. **扫描** — 来源 manifest 统一在 Rust 中以 rayon 并行、1 MiB 缓冲计算 SHA-256。全 PDF 兼容路径使用 `scan_pdf_manifest_native`；混合格式使用 `scan_source_manifest_native`，由 Python 产品层传入格式白名单和单文件大小上限。两者都会返回按文件名排序的 `{doc_id, documents: [{name, size, sha256}]}` manifest。
 2. **比对** — `manifests_match` 仅当 `doc_id`、`chunk_identity_version` 及每个 `{name, sha256}` 都与已存 manifest 一致时才复用索引；任一不匹配都强制重建。
 3. **解析** — PDF 通过 `smart_parse` / PyMuPDF 抽取页文本、按 block 重排双栏，并可在预算内调用本地 Tesseract OCR。统一 `parse_source` 路径为 Markdown/文本/HTML 保留行与章节定位，为 DOCX 保留段落定位，为 PPTX 保留幻灯片定位，为 XLSX 保留工作表/单元格定位，并支持图片来源。
 4. **切块** — `chunk_paper` 先保守识别章节，再把每个 child 限制在 600 字符以内、重叠 60 字符，优先沿段落、句末/分号、换行和空白边界切分，超长无断句文本才退回固定窗口。无结构噪声仍沿用最短 30 字符过滤，但每个非空的已识别章节或 preamble 都会保留，避免章节硬边界抹掉短证据。child 不跨越已识别的章节边界；每块保存稳定 `parent_chunk_id`、章节路径、父级内序号及最多 160 字符的章节内定位上下文，同时保留自己的稳定 `chunk_id` 和页码跨度作为引用身份。
@@ -643,15 +643,18 @@ chunk_id = sha256:{source_sha256}:src:{source_name}:p{page_start}-p{page_end}:c{
 
 ## Rust 原生核心
 
-`rust_core` 是 PyO3/maturin 扩展，通过 `tools.rust_core_loader.ensure_rust_core` 加载；若构建缺失或符号过期，会尽早失败并给出 `maturin develop` 提示。共暴露六个 native 符号，全部登记在 `scripts/check_native.py`，使 `make check` 能对旧构建报错。
+`rust_core` 是 PyO3/maturin 扩展，通过 `tools.rust_core_loader.ensure_rust_core` 加载；若构建缺失或符号过期，会尽早失败并给出 `maturin develop` 提示。运行时所需 native 符号全部登记在 `scripts/check_native.py`，使 `make check` 能对旧构建报错。
 
 | 符号 | 模块 | 用途 |
 | --- | --- | --- |
-| `scan_pdf_manifest_native` | `scanner.rs` | rayon 并行、缓冲式 SHA-256 的全 PDF 快速路径；混合格式改走 Python 来源扫描器 |
+| `scan_pdf_manifest_native` | `scanner.rs` | rayon 并行、缓冲式 SHA-256 的全 PDF 兼容路径 |
+| `list_supported_files_native` | `scanner.rs` | 与 manifest 扫描共用同一格式白名单逻辑的稳定文件枚举 |
+| `scan_source_manifest_native` | `scanner.rs` | 格式白名单约束的通用并行 SHA-256 扫描，并 fail-closed 执行单文件大小上限 |
 | `rrf_fusion_native` | `rrf.rs` | 对 vector + BM25 结果做确定性 RRF（`k=60`）融合，以 `chunk_id` 为键 |
 | `validate_citations_native` | `citation.rs` | 结构化引用校验 → `invalid_sources` / `invalid_pages` / `missing_citations` |
 | `tokenize_mixed_text_native` | `tokenizer.rs` | 中英混合分词：中文走 `jieba-rs`，英文做 Snowball 词干化 + 停用词过滤（标识符/版本号原样保留），与 Python 参照逐 token 对齐 |
 | `tokenize_corpus_native` | `tokenizer.rs` | BM25 建库使用的批量语料分词，避免 Python 侧逐文档分词循环 |
+| `select_evidence_span_native` | `evidence_span.rs` | 单次 native 调用完成 query-aware 分句、窗口评分；Python 保留来源追踪与 ACL materialize |
 | `Bm25Index`（类） | `bm25.rs` | BM25 索引 + `score_topk` + native 字节持久化，与 `rank_bm25.BM25Okapi` 逐位对齐，top-k 在 native 端选出 |
 
 ## 项目结构
@@ -693,7 +696,7 @@ CogDoc/
 | `src/cogdoc/graph/` | LangGraph 状态、主 workflow、QA / Summary / Compare 子图 |
 | `src/cogdoc/service/` | chat / ingest 服务、KB 生命周期、事务化索引、锁、清理和后台任务 |
 | `src/cogdoc/tools/` | 统一来源解析、PDF/OCR、切块、manifest、embedding、rerank、Rust loader 和检索器 |
-| `rust_core/src/` | PyO3 原生内核：scanner、tokenizer、BM25、RRF、citation validator |
+| `rust_core/src/` | PyO3 原生内核：scanner、tokenizer、evidence-span selector、BM25、RRF、citation validator |
 | `scripts/`、`tests/`、`eval/`、`docs/` | 健康检查脚本、测试、离线评测集和项目文档 |
 
 ## 扫描 PDF OCR（可选）

--- a/rust_core/Cargo.lock
+++ b/rust_core/Cargo.lock
@@ -568,6 +568,7 @@ dependencies = [
  "rust-stemmers",
  "serde",
  "sha2",
+ "unicode-casefold",
 ]
 
 [[package]]
@@ -657,6 +658,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-casefold"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f66b1c8f8caa2ab31dc6d3f35386f16efdab89668f93411e565ac368908e8f"
 
 [[package]]
 name = "unicode-ident"

--- a/rust_core/Cargo.toml
+++ b/rust_core/Cargo.toml
@@ -16,5 +16,6 @@ hex = "0.4"
 jieba-rs = "0.10"
 rust-stemmers = "1"
 regex = "1"
+unicode-casefold = "0.2"
 serde = { version = "1", features = ["derive"] }
 bincode = "1.3"

--- a/rust_core/src/evidence_span.rs
+++ b/rust_core/src/evidence_span.rs
@@ -1,0 +1,572 @@
+use regex::Regex;
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashSet};
+use std::sync::OnceLock;
+use unicode_casefold::UnicodeCaseFold;
+
+use crate::tokenizer::tokenize_mixed_text_core;
+
+const REASON_WITHIN_BUDGET: &str = "within_budget";
+const REASON_QUERY_SPAN: &str = "query_span";
+const REASON_LONG_SENTENCE_WINDOW: &str = "long_sentence_window";
+const REASON_FALLBACK_NO_TERMS: &str = "fallback_no_terms";
+const REASON_FALLBACK_NO_MATCH: &str = "fallback_no_match";
+
+static WORD_RE: OnceLock<Regex> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TextSpan {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Selection {
+    pub start: usize,
+    pub end: usize,
+    pub score: f64,
+    pub matched_terms: Vec<String>,
+    pub reason: &'static str,
+    pub fallback: bool,
+}
+
+type Quality = (usize, usize, usize);
+
+struct CharText<'a> {
+    text: &'a str,
+    chars: Vec<char>,
+    byte_offsets: Vec<usize>,
+}
+
+struct FoldedText {
+    text: String,
+    byte_offsets: Vec<usize>,
+    original_indexes: Vec<usize>,
+}
+
+impl FoldedText {
+    fn new(text: &str) -> Self {
+        let mut folded = String::new();
+        let mut original_indexes = Vec::new();
+        for (original_index, character) in text.chars().enumerate() {
+            for folded_character in character.case_fold() {
+                folded.push(folded_character);
+                original_indexes.push(original_index);
+            }
+        }
+        let byte_offsets = folded
+            .char_indices()
+            .map(|(offset, _)| offset)
+            .chain([folded.len()])
+            .collect();
+        Self {
+            text: folded,
+            byte_offsets,
+            original_indexes,
+        }
+    }
+
+    fn original_span(&self, byte_start: usize, byte_end: usize) -> Option<TextSpan> {
+        let folded_start = self
+            .byte_offsets
+            .binary_search(&byte_start)
+            .unwrap_or_else(|index| index);
+        let folded_end = self
+            .byte_offsets
+            .binary_search(&byte_end)
+            .unwrap_or_else(|index| index);
+        if folded_start >= folded_end {
+            return None;
+        }
+        Some(TextSpan {
+            start: self.original_indexes[folded_start],
+            end: self.original_indexes[folded_end - 1] + 1,
+        })
+    }
+}
+
+fn casefold(text: &str) -> String {
+    text.case_fold().collect()
+}
+
+impl<'a> CharText<'a> {
+    fn new(text: &'a str) -> Self {
+        let mut chars = Vec::new();
+        let mut byte_offsets = Vec::new();
+        for (offset, character) in text.char_indices() {
+            byte_offsets.push(offset);
+            chars.push(character);
+        }
+        byte_offsets.push(text.len());
+        Self {
+            text,
+            chars,
+            byte_offsets,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.chars.len()
+    }
+
+    fn slice(&self, start: usize, end: usize) -> &'a str {
+        &self.text[self.byte_offsets[start]..self.byte_offsets[end]]
+    }
+
+    fn char_index_for_byte(&self, byte: usize) -> usize {
+        self.byte_offsets
+            .binary_search(&byte)
+            .unwrap_or_else(|index| index)
+    }
+}
+
+fn word_re() -> &'static Regex {
+    WORD_RE.get_or_init(|| Regex::new(r"[A-Za-z0-9]+(?:[_.-][A-Za-z0-9]+)*").unwrap())
+}
+
+fn stable_tokens(text: &str) -> HashSet<String> {
+    tokenize_mixed_text_core(text)
+        .into_iter()
+        .map(|token| casefold(token.trim()))
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn scoring_tokens(text: &str, target_terms: &[String]) -> HashSet<String> {
+    let mut tokens = stable_tokens(text);
+    let folded = casefold(text);
+    let target: HashSet<&str> = target_terms.iter().map(String::as_str).collect();
+    for term in target_terms {
+        let pure_ascii_alpha = term.is_ascii() && term.chars().all(|ch| ch.is_ascii_alphabetic());
+        if !term.is_empty() && folded.contains(term) && !pure_ascii_alpha {
+            tokens.insert(term.clone());
+        }
+    }
+    for matched in word_re().find_iter(text) {
+        let word = matched.as_str();
+        let mut lexical = stable_tokens(word);
+        lexical.insert(casefold(word));
+        for term in lexical {
+            if target.contains(term.as_str()) {
+                tokens.insert(term);
+            }
+        }
+    }
+    tokens
+}
+
+fn quality(
+    tokens: &HashSet<String>,
+    query_terms: &[String],
+    requirement_terms: &[Vec<String>],
+    all_terms: &[String],
+) -> Quality {
+    let requirement_hits = requirement_terms
+        .iter()
+        .filter(|terms| terms.iter().any(|term| tokens.contains(term)))
+        .count();
+    let query_hits = query_terms
+        .iter()
+        .filter(|term| tokens.contains(*term))
+        .count();
+    let distinct_hits = all_terms
+        .iter()
+        .filter(|term| tokens.contains(*term))
+        .count();
+    (requirement_hits, query_hits, distinct_hits)
+}
+
+fn score(value: Quality) -> f64 {
+    (value.0 * 100 + value.1 * 10 + value.2) as f64
+}
+
+fn matched_terms(tokens: &HashSet<String>, all_terms: &[String]) -> Vec<String> {
+    all_terms
+        .iter()
+        .filter(|term| tokens.contains(*term))
+        .cloned()
+        .collect()
+}
+
+fn is_closing_punctuation(character: char) -> bool {
+    matches!(
+        character,
+        '"' | '\''
+            | '\u{2019}'
+            | '\u{201d}'
+            | ')'
+            | '\u{ff09}'
+            | ']'
+            | '\u{3011}'
+            | '}'
+            | '\u{3009}'
+            | '\u{300d}'
+            | '\u{300f}'
+    )
+}
+
+fn is_sentence_period(chars: &[char], index: usize) -> bool {
+    if chars[index] != '.' {
+        return false;
+    }
+    let previous = index.checked_sub(1).and_then(|pos| chars.get(pos)).copied();
+    let following = chars.get(index + 1).copied();
+    if previous.is_some_and(|ch| ch.is_ascii_digit())
+        && following.is_some_and(|ch| ch.is_ascii_digit())
+    {
+        return false;
+    }
+    following.is_none_or(|ch| ch.is_whitespace() || is_closing_punctuation(ch))
+}
+
+fn trimmed_span(chars: &[char], mut start: usize, mut end: usize) -> Option<TextSpan> {
+    while start < end && chars[start].is_whitespace() {
+        start += 1;
+    }
+    while end > start && chars[end - 1].is_whitespace() {
+        end -= 1;
+    }
+    (start < end).then_some(TextSpan { start, end })
+}
+
+fn sentence_spans(view: &CharText<'_>) -> Vec<TextSpan> {
+    let mut spans = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+    while index < view.len() {
+        let character = view.chars[index];
+        let boundary = character == '\n'
+            || matches!(
+                character,
+                '\u{3002}' | '\u{ff01}' | '\u{ff1f}' | '!' | '?' | '\u{ff1b}' | ';'
+            )
+            || is_sentence_period(&view.chars, index);
+        if !boundary {
+            index += 1;
+            continue;
+        }
+        let mut end = if character == '\n' { index } else { index + 1 };
+        if character != '\n' {
+            while end < view.len() && is_closing_punctuation(view.chars[end]) {
+                end += 1;
+            }
+        }
+        if let Some(span) = trimmed_span(&view.chars, start, end) {
+            spans.push(span);
+        }
+        index = std::cmp::max(index + 1, end);
+        start = index;
+    }
+    if let Some(span) = trimmed_span(&view.chars, start, view.len()) {
+        spans.push(span);
+    }
+    spans
+}
+
+fn matching_intervals(view: &CharText<'_>, terms: &HashSet<String>) -> Vec<TextSpan> {
+    let mut intervals = BTreeSet::new();
+    let folded = FoldedText::new(view.text);
+    for term in terms {
+        if term.is_ascii() && term.chars().all(|ch| ch.is_ascii_alphabetic()) {
+            continue;
+        }
+        let folded_term = casefold(term);
+        for (byte_start, _) in folded.text.match_indices(&folded_term) {
+            if let Some(span) = folded.original_span(byte_start, byte_start + folded_term.len()) {
+                intervals.insert((span.start, span.end));
+            }
+        }
+    }
+    for matched in word_re().find_iter(view.text) {
+        let mut lexical = stable_tokens(matched.as_str());
+        lexical.insert(casefold(matched.as_str()));
+        if lexical.iter().any(|term| terms.contains(term)) {
+            intervals.insert((
+                view.char_index_for_byte(matched.start()),
+                view.char_index_for_byte(matched.end()),
+            ));
+        }
+    }
+    intervals
+        .into_iter()
+        .map(|(start, end)| TextSpan { start, end })
+        .collect()
+}
+
+fn window_around_interval(text_chars: usize, interval: TextSpan, max_chars: usize) -> TextSpan {
+    let interval_chars = interval.end - interval.start;
+    let mut start = if interval_chars >= max_chars {
+        (interval.start + interval.end) / 2 - max_chars / 2
+    } else {
+        interval
+            .start
+            .saturating_sub((max_chars - interval_chars) / 2)
+    };
+    start = std::cmp::min(start, text_chars.saturating_sub(max_chars));
+    TextSpan {
+        start,
+        end: std::cmp::min(text_chars, start + max_chars),
+    }
+}
+
+fn select_long_sentence_window(
+    text: &str,
+    target_terms: &[String],
+    query_terms: &[String],
+    requirement_terms: &[Vec<String>],
+    max_chars: usize,
+) -> Option<Selection> {
+    let view = CharText::new(text);
+    let targets: HashSet<String> = target_terms.iter().cloned().collect();
+    let mut best: Option<(Quality, TextSpan, HashSet<String>)> = None;
+    for interval in matching_intervals(&view, &targets) {
+        let span = window_around_interval(view.len(), interval, max_chars);
+        let tokens = scoring_tokens(view.slice(span.start, span.end), target_terms);
+        let candidate_quality = quality(&tokens, query_terms, requirement_terms, target_terms);
+        let replace = best.as_ref().is_none_or(|(best_quality, best_span, _)| {
+            candidate_quality > *best_quality
+                || (candidate_quality == *best_quality && span.start < best_span.start)
+        });
+        if replace {
+            best = Some((candidate_quality, span, tokens));
+        }
+    }
+    best.map(|(best_quality, span, tokens)| Selection {
+        start: span.start,
+        end: span.end,
+        score: score(best_quality),
+        matched_terms: matched_terms(&tokens, target_terms),
+        reason: REASON_LONG_SENTENCE_WINDOW,
+        fallback: false,
+    })
+}
+
+fn compare_focal(
+    left_quality: Quality,
+    left_index: usize,
+    right_quality: Quality,
+    right_index: usize,
+) -> Ordering {
+    left_quality
+        .cmp(&right_quality)
+        .then_with(|| right_index.cmp(&left_index))
+}
+
+pub fn select_evidence_span_core(
+    text: &str,
+    query_terms: &[String],
+    requirement_terms: &[Vec<String>],
+    target_terms: &[String],
+    max_chars: usize,
+    context_sentences: usize,
+) -> Selection {
+    let view = CharText::new(text);
+    let full_tokens = scoring_tokens(text, target_terms);
+    let full_quality = quality(&full_tokens, query_terms, requirement_terms, target_terms);
+    let full_matches = matched_terms(&full_tokens, target_terms);
+    if view.len() <= max_chars {
+        return Selection {
+            start: 0,
+            end: view.len(),
+            score: score(full_quality),
+            matched_terms: full_matches,
+            reason: REASON_WITHIN_BUDGET,
+            fallback: false,
+        };
+    }
+    if target_terms.is_empty() {
+        return Selection {
+            start: 0,
+            end: view.len(),
+            score: 0.0,
+            matched_terms: Vec::new(),
+            reason: REASON_FALLBACK_NO_TERMS,
+            fallback: true,
+        };
+    }
+    if full_matches.is_empty() {
+        return Selection {
+            start: 0,
+            end: view.len(),
+            score: 0.0,
+            matched_terms: Vec::new(),
+            reason: REASON_FALLBACK_NO_MATCH,
+            fallback: true,
+        };
+    }
+
+    let sentences = sentence_spans(&view);
+    let sentence_tokens: Vec<HashSet<String>> = sentences
+        .iter()
+        .map(|span| scoring_tokens(view.slice(span.start, span.end), target_terms))
+        .collect();
+    let target_set: HashSet<&str> = target_terms.iter().map(String::as_str).collect();
+    let matching_indexes: Vec<usize> = sentence_tokens
+        .iter()
+        .enumerate()
+        .filter(|(_, tokens)| {
+            tokens
+                .iter()
+                .any(|token| target_set.contains(token.as_str()))
+        })
+        .map(|(index, _)| index)
+        .collect();
+    let Some(focal_index) = matching_indexes.into_iter().max_by(|left, right| {
+        compare_focal(
+            quality(
+                &sentence_tokens[*left],
+                query_terms,
+                requirement_terms,
+                target_terms,
+            ),
+            *left,
+            quality(
+                &sentence_tokens[*right],
+                query_terms,
+                requirement_terms,
+                target_terms,
+            ),
+            *right,
+        )
+    }) else {
+        return select_long_sentence_window(
+            text,
+            target_terms,
+            query_terms,
+            requirement_terms,
+            max_chars,
+        )
+        .unwrap_or(Selection {
+            start: 0,
+            end: view.len(),
+            score: 0.0,
+            matched_terms: Vec::new(),
+            reason: REASON_FALLBACK_NO_MATCH,
+            fallback: true,
+        });
+    };
+    let focal = sentences[focal_index];
+    if focal.end - focal.start > max_chars {
+        return select_long_sentence_window(
+            view.slice(focal.start, focal.end),
+            target_terms,
+            query_terms,
+            requirement_terms,
+            max_chars,
+        )
+        .map(|mut selection| {
+            selection.start += focal.start;
+            selection.end += focal.start;
+            selection
+        })
+        .unwrap_or(Selection {
+            start: 0,
+            end: view.len(),
+            score: 0.0,
+            matched_terms: Vec::new(),
+            reason: REASON_FALLBACK_NO_MATCH,
+            fallback: true,
+        });
+    }
+
+    let lower = focal_index.saturating_sub(context_sentences);
+    let upper = std::cmp::min(sentences.len() - 1, focal_index + context_sentences);
+    let mut best: Option<(Quality, usize, usize, TextSpan, HashSet<String>)> = None;
+    for start_index in lower..=focal_index {
+        for end_index in focal_index..=upper {
+            let span = TextSpan {
+                start: sentences[start_index].start,
+                end: sentences[end_index].end,
+            };
+            if span.end - span.start > max_chars {
+                continue;
+            }
+            let tokens = scoring_tokens(view.slice(span.start, span.end), target_terms);
+            let candidate_quality = quality(&tokens, query_terms, requirement_terms, target_terms);
+            let candidate_key = (
+                candidate_quality,
+                end_index - start_index + 1,
+                usize::MAX - (focal_index - start_index).abs_diff(end_index - focal_index),
+                usize::MAX - start_index,
+            );
+            let replace = best
+                .as_ref()
+                .is_none_or(|(best_quality, best_start, best_end, _, _)| {
+                    let best_key = (
+                        *best_quality,
+                        *best_end - *best_start + 1,
+                        usize::MAX - (focal_index - *best_start).abs_diff(*best_end - focal_index),
+                        usize::MAX - *best_start,
+                    );
+                    candidate_key > best_key
+                });
+            if replace {
+                best = Some((candidate_quality, start_index, end_index, span, tokens));
+            }
+        }
+    }
+    let (best_quality, _, _, span, tokens) = best.expect("the focal sentence fits max_chars");
+    Selection {
+        start: span.start,
+        end: span.end,
+        score: score(best_quality),
+        matched_terms: matched_terms(&tokens, target_terms),
+        reason: REASON_QUERY_SPAN,
+        fallback: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_exact_english_sentence() {
+        let text = "Intro sentence. The retrieval system uses hybrid search. Closing note.";
+        let selection = select_evidence_span_core(
+            text,
+            &["hybrid".into(), "retriev".into()],
+            &[],
+            &["hybrid".into(), "retriev".into()],
+            40,
+            0,
+        );
+        let view = CharText::new(text);
+        assert_eq!(
+            view.slice(selection.start, selection.end),
+            "The retrieval system uses hybrid search."
+        );
+        assert_eq!(selection.reason, REASON_QUERY_SPAN);
+    }
+
+    #[test]
+    fn uses_character_offsets_for_chinese() {
+        let text = "背景信息。系统采用向量检索提升召回率。部署成本。";
+        let selection = select_evidence_span_core(
+            text,
+            &["向量".into(), "检索".into()],
+            &[],
+            &["向量".into(), "检索".into()],
+            15,
+            0,
+        );
+        let view = CharText::new(text);
+        assert_eq!(
+            view.slice(selection.start, selection.end),
+            "系统采用向量检索提升召回率。"
+        );
+    }
+
+    #[test]
+    fn full_casefold_matches_python_semantics_and_maps_expansions() {
+        assert_eq!(casefold("Straße İ Σς"), "strasse i\u{307} σσ");
+
+        let folded = FoldedText::new("AİB");
+        let folded_term = "i\u{307}";
+        let byte_start = folded.text.find(folded_term).unwrap();
+        assert_eq!(
+            folded.original_span(byte_start, byte_start + folded_term.len()),
+            Some(TextSpan { start: 1, end: 2 })
+        );
+    }
+}

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -3,6 +3,7 @@ use pyo3::types::{PyDict, PyList};
 
 mod bm25;
 mod citation;
+mod evidence_span;
 mod rrf;
 mod scanner;
 mod tokenizer;
@@ -16,7 +17,7 @@ fn scan_pdf_manifest_native<'py>(
 ) -> PyResult<Bound<'py, PyDict>> {
     let scanned_files = match scanner::parallel_scan_manifest(&doc_dir) {
         Ok(files) => files,
-        Err(e) => return Err(pyo3::exceptions::PyIOError::new_err(e.to_string())),
+        Err(error) => return Err(PyErr::from(error)),
     };
 
     let py_list = PyList::empty(py);
@@ -34,6 +35,44 @@ fn scan_pdf_manifest_native<'py>(
     final_manifest.set_item("doc_dir", doc_dir)?;
     final_manifest.set_item("documents", py_list)?;
 
+    Ok(final_manifest)
+}
+
+// 与通用 manifest 扫描复用同一份格式白名单和目录语义，只返回稳定文件名。
+#[pyfunction]
+fn list_supported_files_native(
+    source_dir: String,
+    supported_extensions: Vec<String>,
+) -> PyResult<Vec<String>> {
+    scanner::list_supported_source_files(&source_dir, &supported_extensions).map_err(PyErr::from)
+}
+
+// 扫描所有受支持来源格式；扩展名与单文件上限由 Python 产品契约传入。
+#[pyfunction]
+fn scan_source_manifest_native<'py>(
+    py: Python<'py>,
+    doc_id: String,
+    doc_dir: String,
+    supported_extensions: Vec<String>,
+    max_source_bytes: u64,
+) -> PyResult<Bound<'py, PyDict>> {
+    let scanned_files =
+        scanner::parallel_scan_source_manifest(&doc_dir, &supported_extensions, max_source_bytes)
+            .map_err(PyErr::from)?;
+
+    let py_list = PyList::empty(py);
+    for file in scanned_files {
+        let single_file_dict = PyDict::new(py);
+        single_file_dict.set_item("name", file.name)?;
+        single_file_dict.set_item("size", file.size)?;
+        single_file_dict.set_item("sha256", file.sha256)?;
+        py_list.append(single_file_dict)?;
+    }
+
+    let final_manifest = PyDict::new(py);
+    final_manifest.set_item("doc_id", doc_id)?;
+    final_manifest.set_item("doc_dir", doc_dir)?;
+    final_manifest.set_item("documents", py_list)?;
     Ok(final_manifest)
 }
 
@@ -70,14 +109,51 @@ fn tokenize_corpus_native(texts: Vec<String>) -> Vec<Vec<String>> {
     tokenizer::tokenize_corpus_core(texts)
 }
 
+// 在一次 native 调用内完成分句、分词、候选窗口评分与稳定决胜。
+#[pyfunction]
+fn select_evidence_span_native<'py>(
+    py: Python<'py>,
+    text: String,
+    query_terms: Vec<String>,
+    requirement_terms: Vec<Vec<String>>,
+    target_terms: Vec<String>,
+    max_chars: usize,
+    context_sentences: usize,
+) -> PyResult<Bound<'py, PyDict>> {
+    if max_chars == 0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "max_chars must be positive",
+        ));
+    }
+    let selection = evidence_span::select_evidence_span_core(
+        &text,
+        &query_terms,
+        &requirement_terms,
+        &target_terms,
+        max_chars,
+        context_sentences,
+    );
+    let result = PyDict::new(py);
+    result.set_item("start", selection.start)?;
+    result.set_item("end", selection.end)?;
+    result.set_item("score", selection.score)?;
+    result.set_item("matched_terms", selection.matched_terms)?;
+    result.set_item("reason", selection.reason)?;
+    result.set_item("fallback", selection.fallback)?;
+    Ok(result)
+}
+
 // 模块入口：向 Python 注册导出的 native 函数
 #[pymodule]
 fn rust_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(scan_pdf_manifest_native, m)?)?;
+    m.add_function(wrap_pyfunction!(list_supported_files_native, m)?)?;
+    m.add_function(wrap_pyfunction!(scan_source_manifest_native, m)?)?;
     m.add_function(wrap_pyfunction!(rrf_fusion_native, m)?)?;
     m.add_function(wrap_pyfunction!(validate_citations_native, m)?)?;
     m.add_function(wrap_pyfunction!(tokenize_mixed_text_native, m)?)?;
     m.add_function(wrap_pyfunction!(tokenize_corpus_native, m)?)?;
+    m.add_function(wrap_pyfunction!(select_evidence_span_native, m)?)?;
     m.add_class::<bm25::Bm25Index>()?;
     Ok(())
 }

--- a/rust_core/src/scanner.rs
+++ b/rust_core/src/scanner.rs
@@ -1,25 +1,135 @@
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // 分块读取文件计算 SHA256，避免大文件一次性占满内存
 pub fn calculate_sha256<P: AsRef<Path>>(path: P) -> std::io::Result<String> {
+    calculate_sha256_bounded(path, u64::MAX).map(|(digest, _)| digest)
+}
+
+fn calculate_sha256_bounded<P: AsRef<Path>>(
+    path: P,
+    max_bytes: u64,
+) -> std::io::Result<(String, u64)> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 1024 * 1024];
 
+    let mut size = 0_u64;
     loop {
         let bytes_read = reader.read(&mut buffer)?;
         if bytes_read == 0 {
             break; // 读到文件末尾
         }
+        size = size.saturating_add(bytes_read as u64);
+        if size > max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("source exceeds {max_bytes} bytes"),
+            ));
+        }
         hasher.update(&buffer[..bytes_read]); // 仅喂入本次实际读到的字节
     }
 
-    Ok(hex::encode(hasher.finalize()))
+    Ok((hex::encode(hasher.finalize()), size))
+}
+
+fn supported_source_paths(
+    doc_dir: &str,
+    supported_extensions: &[String],
+) -> std::io::Result<Vec<PathBuf>> {
+    let dir_path = Path::new(doc_dir);
+    if !dir_path.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "目标目录不存在",
+        ));
+    }
+    if !dir_path.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotADirectory,
+            "目标路径不是目录",
+        ));
+    }
+    let extensions: HashSet<String> = supported_extensions
+        .iter()
+        .map(|value| value.trim_start_matches('.').to_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(dir_path)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file()
+            && path.extension().is_some_and(|extension| {
+                extensions.contains(&extension.to_string_lossy().to_lowercase())
+            })
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+pub fn list_supported_source_files(
+    doc_dir: &str,
+    supported_extensions: &[String],
+) -> std::io::Result<Vec<String>> {
+    supported_source_paths(doc_dir, supported_extensions).map(|paths| {
+        paths
+            .into_iter()
+            .map(|path| {
+                path.file_name()
+                    .expect("read_dir paths always have a file name")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
+    })
+}
+
+// 按调用方提供的格式白名单扫描并行计算指纹，同时保持文件名稳定排序。
+pub fn parallel_scan_source_manifest(
+    doc_dir: &str,
+    supported_extensions: &[String],
+    max_source_bytes: u64,
+) -> std::io::Result<Vec<ScannedFileInfo>> {
+    let paths = supported_source_paths(doc_dir, supported_extensions)?;
+
+    let results: Vec<std::io::Result<(usize, ScannedFileInfo)>> = paths
+        .par_iter()
+        .enumerate()
+        .map(|(index, path)| {
+            let name = path
+                .file_name()
+                .expect("read_dir paths always have a file name")
+                .to_string_lossy()
+                .into_owned();
+            let (sha256, size) =
+                calculate_sha256_bounded(path, max_source_bytes).map_err(|error| {
+                    if error.kind() == std::io::ErrorKind::InvalidData {
+                        std::io::Error::new(
+                            error.kind(),
+                            format!("source exceeds {max_source_bytes} bytes: {name}"),
+                        )
+                    } else {
+                        error
+                    }
+                })?;
+            Ok((index, ScannedFileInfo { name, size, sha256 }))
+        })
+        .collect();
+    let mut valid_files = Vec::with_capacity(results.len());
+    for result in results {
+        valid_files.push(result?);
+    }
+    valid_files.sort_by_key(|(index, _)| *index);
+    Ok(valid_files.into_iter().map(|(_, file)| file).collect())
 }
 
 // 单个 PDF 的指纹信息(文件名/大小/内容哈希)
@@ -31,28 +141,7 @@ pub struct ScannedFileInfo {
 
 // 扫描目录下所有 PDF，并行计算指纹，结果按文件名稳定排序返回
 pub fn parallel_scan_manifest(doc_dir: &str) -> std::io::Result<Vec<ScannedFileInfo>> {
-    let dir_path = Path::new(doc_dir);
-    if !dir_path.exists() || !dir_path.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "目标目录不存在",
-        ));
-    }
-
-    let mut pdf_paths = Vec::new();
-    for entry in std::fs::read_dir(dir_path)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file()
-            && path
-                .extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
-        {
-            pdf_paths.push(path);
-        }
-    }
-
-    pdf_paths.sort(); // 先定序，保证指纹清单顺序稳定
+    let pdf_paths = supported_source_paths(doc_dir, &[".pdf".to_string()])?;
 
     // 并行计算各文件哈希，保留下标用于还原排序
     let results: Vec<std::io::Result<(usize, ScannedFileInfo)>> = pdf_paths

--- a/src/cogdoc/tools/retriever/evidence_spans.py
+++ b/src/cogdoc/tools/retriever/evidence_spans.py
@@ -3,15 +3,30 @@ from __future__ import annotations
 import copy
 import logging
 import re
+import threading
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from types import ModuleType
 from typing import Any, cast
 
 from cogdoc.graph.state import RetrievedDoc
+from cogdoc.tools.rust_core_loader import ensure_rust_core
 from cogdoc.tools.tokenizer import tokenize_mixed_text
 
 
 logger = logging.getLogger(__name__)
+_rust_core: ModuleType | None = None
+_rust_core_lock = threading.Lock()
+
+
+def _get_rust_core() -> ModuleType:
+    global _rust_core
+    if _rust_core is None:
+        with _rust_core_lock:
+            if _rust_core is None:
+                _rust_core = ensure_rust_core("select_evidence_span_native")
+    assert _rust_core is not None
+    return _rust_core
 
 REASON_WITHIN_BUDGET = "within_budget"
 REASON_QUERY_SPAN = "query_span"
@@ -46,8 +61,6 @@ _REQUIREMENT_TEXT_KEYS = (
 )
 _WORD_RE = re.compile(r"[A-Za-z0-9]+(?:[_.-][A-Za-z0-9]+)*")
 _CJK_CHAR_RE = re.compile(r"[\u3400-\u9fff]")
-_CLOSING_PUNCTUATION = frozenset("\"'\u2019\u201d)\uff09]\u3011}\u3009\u300d\u300f")
-_UNCONDITIONAL_SENTENCE_END = frozenset("\u3002\uff01\uff1f!?\uff1b;")
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,12 +86,6 @@ class _SourceView:
     start: int
     end: int
     overlap_chars: int
-
-
-@dataclass(frozen=True, slots=True)
-class _TextSpan:
-    start: int
-    end: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -301,320 +308,6 @@ def _active_requirements(
     )
 
 
-def _is_sentence_period(text: str, index: int) -> bool:
-    if text[index] != ".":
-        return False
-    previous = text[index - 1] if index else ""
-    following = text[index + 1] if index + 1 < len(text) else ""
-    if previous.isdigit() and following.isdigit():
-        return False
-    return not following or following.isspace() or following in _CLOSING_PUNCTUATION
-
-
-def _trimmed_span(text: str, start: int, end: int) -> _TextSpan | None:
-    while start < end and text[start].isspace():
-        start += 1
-    while end > start and text[end - 1].isspace():
-        end -= 1
-    return _TextSpan(start, end) if start < end else None
-
-
-def _sentence_spans(text: str) -> tuple[_TextSpan, ...]:
-    spans: list[_TextSpan] = []
-    start = 0
-    index = 0
-    while index < len(text):
-        char = text[index]
-        boundary = (
-            char == "\n"
-            or char in _UNCONDITIONAL_SENTENCE_END
-            or _is_sentence_period(text, index)
-        )
-        if not boundary:
-            index += 1
-            continue
-        end = index if char == "\n" else index + 1
-        if char != "\n":
-            while end < len(text) and text[end] in _CLOSING_PUNCTUATION:
-                end += 1
-        span = _trimmed_span(text, start, end)
-        if span is not None:
-            spans.append(span)
-        index = max(index + 1, end)
-        start = index
-    span = _trimmed_span(text, start, len(text))
-    if span is not None:
-        spans.append(span)
-    return tuple(spans)
-
-
-def _quality(
-    tokens: set[str],
-    *,
-    query_terms: tuple[str, ...],
-    requirement_terms: tuple[tuple[str, ...], ...],
-    all_terms: tuple[str, ...],
-) -> tuple[int, int, int]:
-    requirement_hits = sum(
-        bool(tokens.intersection(terms)) for terms in requirement_terms
-    )
-    query_hits = len(tokens.intersection(query_terms))
-    distinct_hits = len(tokens.intersection(all_terms))
-    return requirement_hits, query_hits, distinct_hits
-
-
-def _score(quality: tuple[int, int, int]) -> float:
-    requirement_hits, query_hits, distinct_hits = quality
-    return float(requirement_hits * 100 + query_hits * 10 + distinct_hits)
-
-
-def _matched_terms(tokens: set[str], all_terms: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(term for term in all_terms if term in tokens)
-
-
-def _matching_intervals(text: str, terms: set[str]) -> tuple[_TextSpan, ...]:
-    intervals: set[tuple[int, int]] = set()
-    lowered = text.casefold()
-    for term in terms:
-        # Chinese terms and identifiers generally survive tokenization verbatim.
-        # Pure Latin terms may be stems (for example ``retriev``), so matching
-        # them as arbitrary substrings would turn ``art`` into a hit on
-        # ``partial``.  Lexical units below handle those terms safely.
-        if term.isascii() and term.isalpha():
-            continue
-        search_from = 0
-        while term and (found := lowered.find(term, search_from)) >= 0:
-            intervals.add((found, found + len(term)))
-            search_from = found + max(1, len(term))
-    # English terms may be stemmed.  Map the normalized token back to the exact
-    # lexical unit instead of attempting to synthesize a substring.
-    for match in _WORD_RE.finditer(text):
-        lexical_terms = set(_stable_tokens(match.group(0)))
-        lexical_terms.add(match.group(0).casefold())
-        if terms.intersection(lexical_terms):
-            intervals.add((match.start(), match.end()))
-    return tuple(_TextSpan(start, end) for start, end in sorted(intervals))
-
-
-def _scoring_tokens(text: str, target_terms: tuple[str, ...]) -> set[str]:
-    """Include exact lexical hits that the corpus tokenizer punctuates."""
-
-    tokens = set(_stable_tokens(text))
-    lowered = text.casefold()
-    target = set(target_terms)
-    tokens.update(
-        term
-        for term in target_terms
-        if term and term in lowered and (not term.isascii() or not term.isalpha())
-    )
-    for match in _WORD_RE.finditer(text):
-        word_tokens = set(_stable_tokens(match.group(0)))
-        word_tokens.add(match.group(0).casefold())
-        tokens.update(target.intersection(word_tokens))
-    return tokens
-
-
-def _window_around_interval(
-    *,
-    text_chars: int,
-    interval: _TextSpan,
-    max_chars: int,
-) -> _TextSpan:
-    interval_chars = interval.end - interval.start
-    if interval_chars >= max_chars:
-        center = (interval.start + interval.end) // 2
-        start = max(0, center - max_chars // 2)
-    else:
-        left_context = (max_chars - interval_chars) // 2
-        start = max(0, interval.start - left_context)
-    start = min(start, max(0, text_chars - max_chars))
-    return _TextSpan(start, min(text_chars, start + max_chars))
-
-
-def _select_long_sentence_window(
-    text: str,
-    *,
-    target_terms: tuple[str, ...],
-    query_terms: tuple[str, ...],
-    requirement_terms: tuple[tuple[str, ...], ...],
-    max_chars: int,
-) -> _Selection | None:
-    intervals = _matching_intervals(text, set(target_terms))
-    if not intervals:
-        return None
-    choices: list[tuple[tuple[int, int, int], _TextSpan, set[str]]] = []
-    for interval in intervals:
-        span = _window_around_interval(
-            text_chars=len(text), interval=interval, max_chars=max_chars
-        )
-        tokens = _scoring_tokens(text[span.start : span.end], target_terms)
-        quality = _quality(
-            tokens,
-            query_terms=query_terms,
-            requirement_terms=requirement_terms,
-            all_terms=target_terms,
-        )
-        choices.append((quality, span, tokens))
-    quality, span, tokens = max(
-        choices,
-        key=lambda choice: (*choice[0], -choice[1].start),
-    )
-    return _Selection(
-        start=span.start,
-        end=span.end,
-        score=_score(quality),
-        matched_terms=_matched_terms(tokens, target_terms),
-        reason=REASON_LONG_SENTENCE_WINDOW,
-    )
-
-
-def _select_span(
-    text: str,
-    *,
-    query_terms: tuple[str, ...],
-    requirement_terms: tuple[tuple[str, ...], ...],
-    target_terms: tuple[str, ...],
-    max_chars: int,
-    context_sentences: int,
-) -> _Selection:
-    full_tokens = _scoring_tokens(text, target_terms)
-    full_quality = _quality(
-        full_tokens,
-        query_terms=query_terms,
-        requirement_terms=requirement_terms,
-        all_terms=target_terms,
-    )
-    full_matches = _matched_terms(full_tokens, target_terms)
-    if len(text) <= max_chars:
-        return _Selection(
-            0,
-            len(text),
-            _score(full_quality),
-            full_matches,
-            REASON_WITHIN_BUDGET,
-        )
-    if not target_terms:
-        return _Selection(
-            0,
-            len(text),
-            0.0,
-            (),
-            REASON_FALLBACK_NO_TERMS,
-            fallback=True,
-        )
-    if not full_matches:
-        return _Selection(
-            0,
-            len(text),
-            0.0,
-            (),
-            REASON_FALLBACK_NO_MATCH,
-            fallback=True,
-        )
-
-    sentences = _sentence_spans(text)
-    sentence_tokens = [
-        _scoring_tokens(text[span.start : span.end], target_terms) for span in sentences
-    ]
-    matching_sentence_indexes = [
-        index
-        for index, tokens in enumerate(sentence_tokens)
-        if tokens.intersection(target_terms)
-    ]
-    if not matching_sentence_indexes:
-        # This is uncommon (for example, a tokenizer boundary disagreement),
-        # but a raw lexical hit can still provide a trustworthy exact window.
-        window = _select_long_sentence_window(
-            text,
-            target_terms=target_terms,
-            query_terms=query_terms,
-            requirement_terms=requirement_terms,
-            max_chars=max_chars,
-        )
-        if window is not None:
-            return window
-        return _Selection(
-            0,
-            len(text),
-            0.0,
-            (),
-            REASON_FALLBACK_NO_MATCH,
-            fallback=True,
-        )
-
-    focal_index = max(
-        matching_sentence_indexes,
-        key=lambda index: (
-            *_quality(
-                sentence_tokens[index],
-                query_terms=query_terms,
-                requirement_terms=requirement_terms,
-                all_terms=target_terms,
-            ),
-            -index,
-        ),
-    )
-    focal = sentences[focal_index]
-    if focal.end - focal.start > max_chars:
-        focal_text = text[focal.start : focal.end]
-        local_window = _select_long_sentence_window(
-            focal_text,
-            target_terms=target_terms,
-            query_terms=query_terms,
-            requirement_terms=requirement_terms,
-            max_chars=max_chars,
-        )
-        if local_window is not None:
-            return _Selection(
-                start=focal.start + local_window.start,
-                end=focal.start + local_window.end,
-                score=local_window.score,
-                matched_terms=local_window.matched_terms,
-                reason=local_window.reason,
-            )
-        return _Selection(
-            0,
-            len(text),
-            0.0,
-            (),
-            REASON_FALLBACK_NO_MATCH,
-            fallback=True,
-        )
-
-    lower = max(0, focal_index - context_sentences)
-    upper = min(len(sentences) - 1, focal_index + context_sentences)
-    choices: list[tuple[tuple[int, int, int], int, int, _TextSpan, set[str]]] = []
-    for start_index in range(lower, focal_index + 1):
-        for end_index in range(focal_index, upper + 1):
-            span = _TextSpan(sentences[start_index].start, sentences[end_index].end)
-            if span.end - span.start > max_chars:
-                continue
-            tokens = _scoring_tokens(text[span.start : span.end], target_terms)
-            quality = _quality(
-                tokens,
-                query_terms=query_terms,
-                requirement_terms=requirement_terms,
-                all_terms=target_terms,
-            )
-            choices.append((quality, start_index, end_index, span, tokens))
-    quality, start_index, end_index, span, tokens = max(
-        choices,
-        key=lambda choice: (
-            *choice[0],
-            choice[2] - choice[1] + 1,
-            -abs((focal_index - choice[1]) - (choice[2] - focal_index)),
-            -choice[1],
-        ),
-    )
-    return _Selection(
-        start=span.start,
-        end=span.end,
-        score=_score(quality),
-        matched_terms=_matched_terms(tokens, target_terms),
-        reason=REASON_QUERY_SPAN,
-    )
-
-
 def _materialize_doc(
     doc: RetrievedDoc,
     source: _SourceView,
@@ -641,7 +334,7 @@ def _materialize_doc(
     retrieval = dict(_mapping(snapshot.get("retrieval")))
     ultimate_start = source.start + selection.start
     ultimate_end = source.start + selection.end
-    selected_tokens = _scoring_tokens(snapshot["text"], _target_terms((), requirements))
+    selected_tokens = set(selection.matched_terms)
     detected_requirement_ids = [
         requirement.requirement_id
         for requirement in requirements
@@ -736,13 +429,21 @@ class EvidenceSpanSelector:
         )
         target_terms = _target_terms(self._query_terms, requirements)
         source = _source_view(doc)
-        selection = _select_span(
+        native_selection = _get_rust_core().select_evidence_span_native(
             source.text,
-            query_terms=self._query_terms,
-            requirement_terms=requirement_terms,
-            target_terms=target_terms,
-            max_chars=self.max_chars_per_doc,
-            context_sentences=self.context_sentences,
+            list(self._query_terms),
+            [list(terms) for terms in requirement_terms],
+            list(target_terms),
+            self.max_chars_per_doc,
+            self.context_sentences,
+        )
+        selection = _Selection(
+            start=int(native_selection["start"]),
+            end=int(native_selection["end"]),
+            score=float(native_selection["score"]),
+            matched_terms=tuple(str(term) for term in native_selection["matched_terms"]),
+            reason=str(native_selection["reason"]),
+            fallback=bool(native_selection["fallback"]),
         )
         return (
             _materialize_doc(

--- a/src/cogdoc/tools/rust_core_loader.py
+++ b/src/cogdoc/tools/rust_core_loader.py
@@ -5,10 +5,13 @@ from types import ModuleType
 # 运行链路里各处 ensure_rust_core 调用的符号并集；check_native 与就绪探针共用。
 REQUIRED_NATIVE_SYMBOLS = (
     "scan_pdf_manifest_native",
+    "list_supported_files_native",
+    "scan_source_manifest_native",
     "rrf_fusion_native",
     "validate_citations_native",
     "tokenize_mixed_text_native",
     "tokenize_corpus_native",
+    "select_evidence_span_native",
     "Bm25Index",
 )
 

--- a/src/cogdoc/tools/source_parser.py
+++ b/src/cogdoc/tools/source_parser.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import hashlib
 import html
 import mimetypes
 import os
 import re
 import subprocess
+import threading
 import zipfile
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, Iterable, cast
 from xml.etree import ElementTree as ET
 
@@ -24,6 +25,7 @@ from cogdoc.tools.ocr import (
     probe_ocr_dependency,
 )
 from cogdoc.tools.parser import smart_parse
+from cogdoc.tools.rust_core_loader import ensure_rust_core
 
 if TYPE_CHECKING:
     from cogdoc.source_model import SourceDocument
@@ -57,6 +59,20 @@ SUPPORTED_EXTENSIONS = frozenset(
         ".bmp",
     }
 )
+_rust_core: ModuleType | None = None
+_rust_core_lock = threading.Lock()
+
+
+def _get_rust_core() -> ModuleType:
+    global _rust_core
+    if _rust_core is None:
+        with _rust_core_lock:
+            if _rust_core is None:
+                _rust_core = ensure_rust_core(
+                    "list_supported_files_native", "scan_source_manifest_native"
+                )
+    assert _rust_core is not None
+    return _rust_core
 
 
 class SourceParseError(RuntimeError):
@@ -72,34 +88,28 @@ class UnsafeSourceArchiveError(SourceParseError):
 
 
 def list_supported_files(source_dir: str) -> list[str]:
-    return sorted(
-        name
-        for name in os.listdir(source_dir)
-        if Path(name).suffix.casefold() in SUPPORTED_EXTENSIONS
-        and os.path.isfile(os.path.join(source_dir, name))
+    return list(
+        _get_rust_core().list_supported_files_native(
+            os.path.abspath(source_dir), sorted(SUPPORTED_EXTENSIONS)
+        )
     )
 
 
 def scan_source_manifest(kb_id: str, source_dir: str) -> dict[str, Any]:
-    documents = []
-    for name in list_supported_files(source_dir):
-        path = os.path.join(source_dir, name)
-        digest = hashlib.sha256()
-        size = 0
-        with open(path, "rb") as handle:
-            while block := handle.read(1024 * 1024):
-                size += len(block)
-                if size > MAX_SOURCE_BYTES:
-                    raise SourceParseError(
-                        f"source exceeds {MAX_SOURCE_BYTES} bytes: {name}"
-                    )
-                digest.update(block)
-        documents.append({"name": name, "size": size, "sha256": digest.hexdigest()})
-    return {
-        "doc_id": kb_id,
-        "doc_dir": os.path.abspath(source_dir),
-        "documents": documents,
-    }
+    try:
+        return _get_rust_core().scan_source_manifest_native(
+            kb_id,
+            os.path.abspath(source_dir),
+            sorted(SUPPORTED_EXTENSIONS),
+            MAX_SOURCE_BYTES,
+        )
+    except (FileNotFoundError, NotADirectoryError):
+        raise
+    except OSError as exc:
+        message = str(exc)
+        if (offset := message.find("source exceeds ")) >= 0:
+            message = message[offset:]
+        raise SourceParseError(message) from exc
 
 
 def _page(source: str, number: int, text: str, **metadata: Any) -> dict[str, Any]:

--- a/tests/test_manifest_scanner.py
+++ b/tests/test_manifest_scanner.py
@@ -1,7 +1,11 @@
 import pytest
 from tests._native import require_rust_core
 
-rust_core = require_rust_core("scan_pdf_manifest_native")
+rust_core = require_rust_core(
+    "list_supported_files_native",
+    "scan_pdf_manifest_native",
+    "scan_source_manifest_native",
+)
 
 
 # 写入。
@@ -85,5 +89,47 @@ def test_identical_content_is_stable_across_scans(tmp_path):
 def test_missing_directory_raises(tmp_path):
     # 验证目录不存在时 native scanner 抛出异常。
     missing = tmp_path / "does_not_exist"
-    with pytest.raises(Exception):
+    with pytest.raises(FileNotFoundError):
         rust_core.scan_pdf_manifest_native("kb", str(missing))
+
+
+def test_pdf_manifest_rejects_non_directory_with_specific_error(tmp_path):
+    regular_file = tmp_path / "regular.pdf"
+    _write(regular_file)
+
+    with pytest.raises(NotADirectoryError):
+        rust_core.scan_pdf_manifest_native("kb", str(regular_file))
+
+
+def test_source_manifest_scans_allowlist_and_enforces_per_file_limit(tmp_path):
+    _write(tmp_path / "a.md", b"abc")
+    _write(tmp_path / "b.TXT", b"1234")
+    _write(tmp_path / "ignored.pdf", b"pdf")
+
+    manifest = rust_core.scan_source_manifest_native(
+        "kb", str(tmp_path), [".md", ".txt"], 4
+    )
+
+    assert _names(manifest) == ["a.md", "b.TXT"]
+    assert [row["size"] for row in manifest["documents"]] == [3, 4]
+    assert rust_core.list_supported_files_native(
+        str(tmp_path), [".md", ".txt"]
+    ) == ["a.md", "b.TXT"]
+
+    with pytest.raises(OSError, match=r"source exceeds 2 bytes: a\.md"):
+        rust_core.scan_source_manifest_native(
+            "kb", str(tmp_path), [".md"], 2
+        )
+
+
+def test_source_manifest_preserves_missing_and_not_directory_errors(tmp_path):
+    missing = tmp_path / "missing"
+    regular_file = tmp_path / "regular.txt"
+    regular_file.write_text("content", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError):
+        rust_core.scan_source_manifest_native("kb", str(missing), [".txt"], 10)
+    with pytest.raises(NotADirectoryError):
+        rust_core.scan_source_manifest_native(
+            "kb", str(regular_file), [".txt"], 10
+        )

--- a/tests/test_source_parser.py
+++ b/tests/test_source_parser.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from cogdoc.tools import source_parser as source_parser_module
 from cogdoc.config.settings import Settings
 from cogdoc.tools.source_parser import (
     SourceParseError,
@@ -210,3 +211,24 @@ def test_manifest_scans_all_supported_formats_deterministically(tmp_path):
     (tmp_path / "ignored.exe").write_bytes(b"x")
     manifest = scan_source_manifest("kb", str(tmp_path))
     assert [row["name"] for row in manifest["documents"]] == ["a.txt", "b.md"]
+
+
+def test_manifest_preserves_filesystem_exception_contract(tmp_path):
+    missing = tmp_path / "missing"
+    regular_file = tmp_path / "regular.txt"
+    regular_file.write_text("content", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError):
+        scan_source_manifest("kb", str(missing))
+    with pytest.raises(NotADirectoryError):
+        scan_source_manifest("kb", str(regular_file))
+
+
+def test_manifest_preserves_source_size_error_contract(tmp_path, monkeypatch):
+    (tmp_path / "oversized.md").write_bytes(b"abc")
+    monkeypatch.setattr(source_parser_module, "MAX_SOURCE_BYTES", 2)
+
+    with pytest.raises(SourceParseError) as raised:
+        scan_source_manifest("kb", str(tmp_path))
+
+    assert str(raised.value) == "source exceeds 2 bytes: oversized.md"


### PR DESCRIPTION
## Summary
- move evidence span selection into the Rust core with Unicode casefold-compatible offsets
- move source manifest scanning and supported-file listing into the shared Rust scanner
- preserve lazy loading, exception contracts, and add regression coverage

## Validation
- cargo fmt --check and cargo test --locked (7 passed)
- make lint and make typecheck-security
- full pytest with Postgres/MinIO (2978 passed)
- API, account-auth, and eval smoke gates
- make web-check and make web-e2e (41 passed)
- Python 3.13 manylinux wheel symbol check
- container account-auth, backup verification, and restore drill